### PR TITLE
Option tags supports quotation-mark-less values

### DIFF
--- a/JBBCode/CodeDefinition.php
+++ b/JBBCode/CodeDefinition.php
@@ -35,12 +35,18 @@ class CodeDefinition
     /* The input validator to run the body ({param}) through */
     protected $bodyValidator;
 
+    /* Whether this tag is unary or not */
+    protected $unary;
+
+    /* Whether this tag (if unary) will encompass text past it until next tag, or not */
+    protected $unaryExpand;
+
     /**
      * Constructs a new CodeDefinition.
      */
     public static function construct($tagName, $replacementText, $useOption = false,
             $parseContent = true, $nestLimit = -1, $optionValidator = array(),
-            $bodyValidator = null)
+            $bodyValidator = null, $unary = false, $unaryExpand = false)
     {
         $def = new CodeDefinition();
         $def->elCounter = 0;
@@ -51,6 +57,8 @@ class CodeDefinition
         $def->nestLimit = $nestLimit;
         $def->optionValidator = $optionValidator;
         $def->bodyValidator = $bodyValidator;
+        $def->unary = $unary;
+        $def->unaryExpand = $unaryExpand;
         return $def;
      }
 
@@ -72,6 +80,8 @@ class CodeDefinition
         $this->elCounter = 0;
         $this->optionValidator = array();
         $this->bodyValidator = null;
+        $this->unary = false;
+        $this->unaryExpand = false;
     }
 
     /**
@@ -230,6 +240,22 @@ class CodeDefinition
     public function getNestLimit()
     {
         return $this->nestLimit;
+    }
+
+    /**
+     * Returns whether this element is a unary tag
+     */
+    public function getUnary()
+    {
+        return $this->unary;
+    }
+
+    /**
+     * Returns whether this element is a unary-expanding tag
+     */
+    public function getUnaryExpand()
+    {
+        return $this->unaryExpand;
     }
 
     /**

--- a/JBBCode/CodeDefinitionBuilder.php
+++ b/JBBCode/CodeDefinitionBuilder.php
@@ -20,6 +20,8 @@ class CodeDefinitionBuilder
     protected $nestLimit = -1;
     protected $optionValidator = array();
     protected $bodyValidator = null;
+    protected $unary = false;
+    protected $unaryExpand = false;
 
     /**
      * Construct a CodeDefinitionBuilder.
@@ -122,6 +124,19 @@ class CodeDefinitionBuilder
     }
 
     /**
+     * Sets whether it's a unary tag or not
+     *
+     * @param $unary  true/false value for whether tag is unary
+     * @param $expand whether tag will encompass text past the tag (true) or not
+     */
+    public function setUnary($unary, $expand = false)
+    {
+        $this->unary = $unary;
+        $this->unaryExpand = $expand;
+        return $this;
+    }
+
+    /**
      * Removes the attached option validator if one is attached.
      */
     public function removeOptionValidator()
@@ -152,7 +167,9 @@ class CodeDefinitionBuilder
                                                 $this->parseContent,
                                                 $this->nestLimit,
                                                 $this->optionValidator,
-                                                $this->bodyValidator);
+                                                $this->bodyValidator,
+                                                $this->unary,
+                                                $this->unaryExpand);
         return $definition;
     }
 

--- a/JBBCode/Parser.php
+++ b/JBBCode/Parser.php
@@ -442,10 +442,20 @@ class Parser
                                 $state = static::OPTION_STATE_QUOTED_VALUE;
                                 break;
                             case null: // intentional fall-through
-                            case ' ': // key=value<space> delimits to next key
                                 $values[] = $buffer;
                                 $buffer = "";
                                 $state = static::OPTION_STATE_KEY;
+                                break;
+                            case ' ':
+                                // peek ahead, if it's a key after this ([a-z]+=)
+                                if (preg_match('/^[a-z]+=/', substr($tagContent, $idx+1)) !== 0) {
+                                    $values[] = $buffer;
+                                    $buffer = "";
+                                    $state = static::OPTION_STATE_KEY;
+                                    break;
+                                } else {
+                                    $buffer .= $char;
+                                }
                                 break;
                             case ":":
                                 if($buffer=="javascript"){

--- a/JBBCode/tests/ParsingEdgeCaseTest.php
+++ b/JBBCode/tests/ParsingEdgeCaseTest.php
@@ -23,6 +23,11 @@ class ParsingEdgeCaseTest extends PHPUnit_Framework_TestCase
     {
         $parser = new JBBCode\Parser();
         $parser->addCodeDefinitionSet(new JBBCode\DefaultCodeDefinitionSet());
+
+        $builder = new JBBCode\CodeDefinitionBuilder('quote', '<p>{option} wrote:</p><blockquote>{param}</blockquote>');
+        $builder->setUseOption(true);
+        $parser->addCodeDefinition($builder->build());
+
         $parser->parse($bbcode);
         return $parser->getAsHtml();
     }
@@ -127,4 +132,12 @@ class ParsingEdgeCaseTest extends PHPUnit_Framework_TestCase
                               '[ ABC ] ');
     }
 
+    /**
+     * Tests having whitespace within options without quotation marks
+     */
+    public function testWhitespaceWithinOptions()
+    {
+        $this->assertProduces('[quote=hello hello]test[/quote]',
+                              '<p>hello hello wrote:</p><blockquote>test</blockquote>');
+    }
 }

--- a/JBBCode/tests/ParsingEdgeCaseTest.php
+++ b/JBBCode/tests/ParsingEdgeCaseTest.php
@@ -24,10 +24,6 @@ class ParsingEdgeCaseTest extends PHPUnit_Framework_TestCase
         $parser = new JBBCode\Parser();
         $parser->addCodeDefinitionSet(new JBBCode\DefaultCodeDefinitionSet());
 
-        $builder = new JBBCode\CodeDefinitionBuilder('quote', '<p>{option} wrote:</p><blockquote>{param}</blockquote>');
-        $builder->setUseOption(true);
-        $parser->addCodeDefinition($builder->build());
-
         $parser->parse($bbcode);
         return $parser->getAsHtml();
     }
@@ -134,10 +130,38 @@ class ParsingEdgeCaseTest extends PHPUnit_Framework_TestCase
 
     /**
      * Tests having whitespace within options without quotation marks
+     *
+     * Non-default definition, thus parser code is re-written here
      */
     public function testWhitespaceWithinOptions()
     {
-        $this->assertProduces('[quote=hello hello]test[/quote]',
+        $parser = new JBBCode\Parser();
+        $parser->addCodeDefinitionSet(new JBBCode\DefaultCodeDefinitionSet());
+
+        $builder = new JBBCode\CodeDefinitionBuilder('quote', '<p>{option} wrote:</p><blockquote>{param}</blockquote>');
+        $builder->setUseOption(true);
+        $parser->addCodeDefinition($builder->build());
+
+        $this->assertEquals($parser->parse('[quote=hello hello]test[/quote]')->getAsHTML(),
                               '<p>hello hello wrote:</p><blockquote>test</blockquote>');
+    }
+
+    /**
+     * Tests having whitespace within options without quotation marks, with
+     * additional key afterwards
+     *
+     * Non-default definition, thus parser code is re-written here
+     */
+    public function testWhitespaceWithinOptionsWithKey()
+    {
+        $parser = new JBBCode\Parser();
+        $parser->addCodeDefinitionSet(new JBBCode\DefaultCodeDefinitionSet());
+
+        $builder = new JBBCode\CodeDefinitionBuilder('quote', '<p>{quote} wrote:</p><blockquote>{param} by {by}</blockquote>');
+        $builder->setUseOption(true);
+        $parser->addCodeDefinition($builder->build());
+
+        $this->assertEquals($parser->parse('[quote=hello hello by=someone]test[/quote]')->getAsHTML(),
+                              '<p>hello hello wrote:</p><blockquote>test by someone</blockquote>');
     }
 }

--- a/JBBCode/tests/UnaryTest.php
+++ b/JBBCode/tests/UnaryTest.php
@@ -1,0 +1,64 @@
+<?php
+
+require_once(dirname(dirname(__FILE__)) . DIRECTORY_SEPARATOR . 'Parser.php');
+require_once(dirname(dirname(__FILE__)) . DIRECTORY_SEPARATOR . 'CodeDefinitionBuilder.php');
+
+/**
+ * Test cases with unary tags
+ *
+ * @author lorentzkim
+ */
+class UnaryTest extends PHPUnit_Framework_TestCase
+{
+    private function defaultHtmlParse($bbcode)
+    {
+        $parser = new JBBCode\Parser();
+        $parser->addCodeDefinitionSet(new JBBCode\DefaultCodeDefinitionSet());
+
+        /* [list] tag */
+        $builder = new JBBCode\CodeDefinitionBuilder('list', '<ul>{param}</ul>');
+        $builder->setUseOption(false);
+        $parser->addCodeDefinition($builder->build());
+
+        /* [*] tag */
+        $builder = new JBBCode\CodeDefinitionBuilder('*', '<li>{param}</li>');
+        $builder->setUseOption(false)->setUnary(true, true);
+        $parser->addCodeDefinition($builder->build());
+
+        /* [search] tag */
+        $builder = new JBBCode\CodeDefinitionBuilder('user', '<a href="/user/{option}">{option}</a>');
+        $builder->setUseOption(true)->setUnary(true);
+        $parser->addCodeDefinition($builder->build());
+
+        $parser->parse($bbcode);
+        return $parser->getAsHTML();
+    }
+
+    /**
+     * Asserts that the given bbcode matches the given text when
+     * the bbcode is run through defaultTextParse
+     */
+    private function assertHtmlOutput($bbcode, $text)
+    {
+        $this->assertEquals($text, $this->defaultHtmlParse($bbcode));
+    }
+
+    public function testUnaryList()
+    {
+        /*$this->assertHtmlOutput('[list][*]a[/list]', '<ul><li>a</li></ul>');
+        $this->assertHtmlOutput('[list][*]a[*]b[/list]', '<ul><li>a</li><li>b</li></ul>');
+        $this->assertHtmlOutput('[list][*]a[*]b[*]c[/list]', '<ul><li>a</li><li>b</li><li>c</li></ul>');
+        $this->assertHtmlOutput('[list][*]a [*]b [*]c [*]d [/list]', '<ul><li>a </li><li>b </li><li>c </li><li>d </li></ul>');
+
+        $this->assertHtmlOutput('[*]a b c d e', '<li>a b c d e</li>');
+        $this->assertHtmlOutput('[*] a b c d e', '<li> a b c d e</li>');*/
+    }
+
+    public function testUnaryUser()
+    {
+        //$this->assertHtmlOutput('foo[user=whoami]', 'foo<a href="/user/whoami">whoami</a>');
+        //$this->assertHtmlOutput('[user=whoami] something entirely else', '<a href="/user/whoami">whoami</a> something entirely else');
+        $this->assertHtmlOutput('[user=whoami][user=it is me]', '<a href="/user/whoami">whoami</a><a href="/user/it is me">it is me</a>');
+        //$this->assertHtmlOutput('[user=whoami] [user=it is me]', '<a href="/user/whoami">whoami</a> <a href="/user/it is me">it is me</a>');
+    }
+}

--- a/JBBCode/tests/UnaryTest.php
+++ b/JBBCode/tests/UnaryTest.php
@@ -45,20 +45,21 @@ class UnaryTest extends PHPUnit_Framework_TestCase
 
     public function testUnaryList()
     {
-        /*$this->assertHtmlOutput('[list][*]a[/list]', '<ul><li>a</li></ul>');
+        $this->assertHtmlOutput('[list][*]a[/list]', '<ul><li>a</li></ul>');
         $this->assertHtmlOutput('[list][*]a[*]b[/list]', '<ul><li>a</li><li>b</li></ul>');
         $this->assertHtmlOutput('[list][*]a[*]b[*]c[/list]', '<ul><li>a</li><li>b</li><li>c</li></ul>');
         $this->assertHtmlOutput('[list][*]a [*]b [*]c [*]d [/list]', '<ul><li>a </li><li>b </li><li>c </li><li>d </li></ul>');
 
         $this->assertHtmlOutput('[*]a b c d e', '<li>a b c d e</li>');
-        $this->assertHtmlOutput('[*] a b c d e', '<li> a b c d e</li>');*/
+        $this->assertHtmlOutput('[*] a b c d e', '<li> a b c d e</li>');
     }
 
     public function testUnaryUser()
     {
-        //$this->assertHtmlOutput('foo[user=whoami]', 'foo<a href="/user/whoami">whoami</a>');
-        //$this->assertHtmlOutput('[user=whoami] something entirely else', '<a href="/user/whoami">whoami</a> something entirely else');
+        $this->assertHtmlOutput('foo[user=whoami]', 'foo<a href="/user/whoami">whoami</a>');
+        $this->assertHtmlOutput('[user=whoami] something entirely else', '<a href="/user/whoami">whoami</a> something entirely else');
         $this->assertHtmlOutput('[user=whoami][user=it is me]', '<a href="/user/whoami">whoami</a><a href="/user/it is me">it is me</a>');
-        //$this->assertHtmlOutput('[user=whoami] [user=it is me]', '<a href="/user/whoami">whoami</a> <a href="/user/it is me">it is me</a>');
+        $this->assertHtmlOutput('[user=whoami] [user=it is me]', '<a href="/user/whoami">whoami</a> <a href="/user/it is me">it is me</a>');
+        $this->assertHtmlOutput('[user=whoami]   [user=it is me]', '<a href="/user/whoami">whoami</a>   <a href="/user/it is me">it is me</a>');
     }
 }


### PR DESCRIPTION
Existing jBBCode cannot handle tags e.g.:

[quote=foo]bar[/quote]

These changes allow exactly that, while still allowing for other considerations (e.g. keyed option values).

I do recognise that there's a preg_match() used for a lookup ahead to peek for existence of a key value; alternative leaner/cleaner/etc solutions will be welcome.