### PR TITLE
Handle newlines

### DIFF
--- a/JBBCode/Parser.php
+++ b/JBBCode/Parser.php
@@ -409,10 +409,15 @@ class Parser
                                 $buffer = "";
                                 break;
                             case ' ':
-                                $state = static::OPTION_STATE_DEFAULT;
-                                $tagName = $buffer;
-                                $buffer = '';
-                                $keys[] = $tagName;
+                                if($buffer) {
+                                    $state = static::OPTION_STATE_DEFAULT;
+                                    $tagName = $buffer;
+                                    $buffer = '';
+                                    $keys[] = $tagName;
+                                }
+                                break;
+                            case "\n":
+                            case "\r":
                                 break;
 
                             case null:
@@ -442,7 +447,7 @@ class Parser
                                 break;
                             case null: // intentional fall-through
                             case ' ': // key=value<space> delimits to next key
-                                $values[] = $buffer;
+                                $values[] = trim($buffer);
                                 $buffer = "";
                                 $state = static::OPTION_STATE_KEY;
                                 break;
@@ -476,7 +481,7 @@ class Parser
                         switch($char){
                             case '=':
                                 $state = static::OPTION_STATE_VALUE;
-                                $keys[] = $buffer;
+                                $keys[] = trim($buffer);
                                 $buffer = '';
                                 break;
                             case ' ': // ignore <space>key=value

--- a/JBBCode/tests/BBCodeToBBCodeTest.php
+++ b/JBBCode/tests/BBCodeToBBCodeTest.php
@@ -65,7 +65,15 @@ class BBCodeToBBCodeTest extends PHPUnit_Framework_TestCase
         $this->assertBBCodeOutput($code, $codeOutput);
     }
 
-    /**
+    public function testCodeOptionsWithNewline()
+    {
+        $code = 'This contains a [
+        url=http://jbbcode.com]url[/url] which uses an option, and has a newline in the tag.';
+        $codeOutput = 'This contains a [url=http://jbbcode.com]url[/url] which uses an option, and has a newline in the tag.';
+        $this->assertBBCodeOutput($code, $codeOutput);
+    }
+
+	/**
      * @depends testCodeOptions
      */
     public function testOmittedOption()


### PR DESCRIPTION
Fix for https://github.com/jbowens/jBBCode/issues/31

Hardens tag options parsing a bit so that neither newlines nor extra spaces break anything. eg.

```
This contains a [
        url=http://jbbcode.com   ]url[/url] which uses an option, and has a newline in the tag.
```
