### PR TITLE
[RFC] Faster Lookup for Codes/Tags

### DIFF
--- a/JBBCode/Parser.php
+++ b/JBBCode/Parser.php
@@ -97,7 +97,7 @@ class Parser
      */
     public function addCodeDefinition(CodeDefinition $definition)
     {
-        $this->bbcodes[$this->getTagKey($definition->getTagName(), $definition->usesOption())] = $definition;
+        $this->bbcodes[$definition->getTagName()][$definition->usesOption()] = $definition;
         return $this;
     }
 
@@ -227,7 +227,7 @@ class Parser
      */
     public function codeExists($tagName, $usesOption = false)
     {
-        return isset($this->bbcodes[$this->getTagKey($tagName,$usesOption)]);
+        return isset($this->bbcodes[strtolower($tagName)][$usesOption]);
     }
 
     /**
@@ -241,25 +241,10 @@ class Parser
     public function getCode($tagName, $usesOption = false)
     {
         if($this->codeExists($tagName, $usesOption)) {
-            return $this->bbcodes[$this->getTagKey($tagName,$usesOption)];
+            return $this->bbcodes[strtolower($tagName)][$usesOption];
         }
 
         return null;
-    }
-
-    /**
-     * Returns a key for the given combination of tag name and usesOption parameter
-     *
-     * @param string  $tagName    the name of the tag for which a key is to be generated
-     * @param boolean $usesOption whether or not the given tag accepts an option
-     * @return string a key representing tag and option
-     */
-    protected function getTagKey($tagName, $usesOption = false)
-    {
-        return serialize(array(
-            strtolower($tagName),
-            $usesOption
-        ));
     }
 
     /**

--- a/JBBCode/Parser.php
+++ b/JBBCode/Parser.php
@@ -97,7 +97,7 @@ class Parser
      */
     public function addCodeDefinition(CodeDefinition $definition)
     {
-        $this->bbcodes[] = $definition;
+        $this->bbcodes[$this->getTagKey($definition->getTagName(), $definition->usesOption())] = $definition;
         return $this;
     }
 
@@ -227,13 +227,7 @@ class Parser
      */
     public function codeExists($tagName, $usesOption = false)
     {
-        foreach ($this->bbcodes as $code) {
-            if (strtolower($tagName) == $code->getTagName() && $usesOption == $code->usesOption()) {
-                return true;
-            }
-        }
-
-        return false;
+        return isset($this->bbcodes[$this->getTagKey($tagName,$usesOption)]);
     }
 
     /**
@@ -246,13 +240,26 @@ class Parser
      */
     public function getCode($tagName, $usesOption = false)
     {
-        foreach ($this->bbcodes as $code) {
-            if (strtolower($tagName) == $code->getTagName() && $code->usesOption() == $usesOption) {
-                return $code;
-            }
+        if($this->codeExists($tagName, $usesOption)) {
+            return $this->bbcodes[$this->getTagKey($tagName,$usesOption)];
         }
 
         return null;
+    }
+
+    /**
+     * Returns a key for the given combination of tag name and usesOption parameter
+     *
+     * @param string  $tagName    the name of the tag for which a key is to be generated
+     * @param boolean $usesOption whether or not the given tag accepts an option
+     * @return string a key representing tag and option
+     */
+    protected function getTagKey($tagName, $usesOption = false)
+    {
+        return serialize(array(
+            strtolower($tagName),
+            $usesOption
+        ));
     }
 
     /**


### PR DESCRIPTION
This PR allows for 𝓞(1) lookups for tags in the parser opposed to the 𝓞(n) lookups currently present.

It bears mentioning that this will introduce a behavioural change: ATM the *first* match for a pair of `$tagName` / `$usesOption` is the winning one. After pulling this, the *last* one will win. In addition, this is probably a mere ”feel good” and/or academic change: Performance improvements are only to be expected with very large inputs while having a lot of tags registered.