### PR TITLE
[RFC] New tokenizer code

### DIFF
--- a/JBBCode/Tokenizer.php
+++ b/JBBCode/Tokenizer.php
@@ -26,15 +26,15 @@ class Tokenizer
         $strLen = strlen($str);
         $position = 0;
 
-        while($position < $strLen) {
+        while ($position < $strLen) {
             $offset = strcspn($str, '[]', $position);
             //Have we hit a single ']' or '['?
-            if($offset == 0) {
+            if ($offset == 0) {
                 $this->tokens[] = $str{$position};
                 $position++;
             } else {
                 $this->tokens[] = substr($str, $position, $offset);
-                $position+=$offset;
+                $position += $offset;
             }
         }
     }

--- a/JBBCode/Tokenizer.php
+++ b/JBBCode/Tokenizer.php
@@ -28,6 +28,7 @@ class Tokenizer
 
         while($position < $strLen) {
             $offset = strcspn($str, '[]', $position);
+            //Have we hit a single ']' or '['?
             if($offset == 0) {
                 $this->tokens[] = $str{$position};
                 $position++;

--- a/JBBCode/Tokenizer.php
+++ b/JBBCode/Tokenizer.php
@@ -23,25 +23,18 @@ class Tokenizer
      */
     public function __construct($str)
     {
-        $strStart = 0;
         $strLen = strlen($str);
-        for ($index = 0; $index < $strLen; ++$index) {
-            if (']' == $str[$index] || '[' == $str[$index]) {
-                /* Are there characters in the buffer from a previous string? */
-                if ($strStart < $index) {
-                    $this->tokens[] = substr($str, $strStart, $index - $strStart);
-                    $strStart = $index;
-                }
+        $position = 0;
 
-                /* Add the [ or ] to the tokens array. */
-                $this->tokens[] = $str[$index];
-                $strStart = $index+1;
+        while($position < $strLen) {
+            $offset = strcspn($str, '[]', $position);
+            if($offset == 0) {
+                $this->tokens[] = $str{$position};
+                $position++;
+            } else {
+                $this->tokens[] = substr($str, $position, $offset);
+                $position+=$offset;
             }
-        }
-
-        if ($strStart < $strLen) {
-            /* There are still characters in the buffer. Add them to the tokens. */
-            $this->tokens[] = substr($str, $strStart, $strLen - $strStart);
         }
     }
 

--- a/JBBCode/Tokenizer.php
+++ b/JBBCode/Tokenizer.php
@@ -30,7 +30,7 @@ class Tokenizer
             $offset = strcspn($str, '[]', $position);
             //Have we hit a single ']' or '['?
             if ($offset == 0) {
-                $this->tokens[] = $str{$position};
+                $this->tokens[] = $str[$position];
                 $position++;
             } else {
                 $this->tokens[] = substr($str, $position, $offset);


### PR DESCRIPTION
Instead of searching through the input entirely character-wise in PHP userland, we could let [`strcspn()`](http://php.net/manual/function.strcspn.php) do the job. Runtimes of the testsuite greatly fail to reflect this, but this is great for longer, more complex input.