### PR TITLE
[RFC] Tokenizer string deduplication

### DIFF
--- a/JBBCode/Tokenizer.php
+++ b/JBBCode/Tokenizer.php
@@ -12,8 +12,16 @@ namespace JBBCode;
 class Tokenizer
 {
 
+    /**
+     * @var integer[]
+     */
     protected $tokens = array();
-    protected $i = -1;
+
+    /**
+     * @var integer current position in the tokens[] array
+     */
+    protected $currentPosition = -1;
+    protected $string;
 
     /**
      * Constructs a tokenizer from the given string. The string will be tokenized
@@ -24,17 +32,17 @@ class Tokenizer
     public function __construct($str)
     {
         $strLen = strlen($str);
+        $this->string = $str;
         $position = 0;
 
         while($position < $strLen) {
-            $offset = strcspn($str, '[]', $position);
-            //Have we hit a single ']' or '['?
+            $offset = strcspn($this->string, '[]', $position);
             if($offset == 0) {
-                $this->tokens[] = $str{$position};
+                $this->tokens[] = $position;
                 $position++;
             } else {
-                $this->tokens[] = substr($str, $position, $offset);
-                $position+=$offset;
+                $this->tokens[] = $position;
+                $position += $offset;
             }
         }
     }
@@ -45,7 +53,7 @@ class Tokenizer
      */
     public function hasNext()
     {
-        return isset($this->tokens[$this->i + 1]);
+        return isset($this->tokens[$this->currentPosition + 1]);
     }
 
     /**
@@ -57,7 +65,8 @@ class Tokenizer
         if (!$this->hasNext()) {
             return null;
         } else {
-            return $this->tokens[++$this->i];
+            $this->currentPosition++;
+            return $this->current();
         }
     }
 
@@ -67,10 +76,16 @@ class Tokenizer
      */
     public function current()
     {
-        if ($this->i < 0) {
+        if ($this->currentPosition < 0) {
             return null;
         } else {
-            return $this->tokens[$this->i];
+            $start = $this->tokens[$this->currentPosition];
+            if($this->hasNext()) {
+                $length = $this->tokens[$this->currentPosition + 1] - $start;
+                return substr($this->string, $start, $length);
+            } else {
+                return substr($this->string, $start);
+            }
         }
     }
 
@@ -79,8 +94,8 @@ class Tokenizer
      */
     public function stepBack()
     {
-        if ($this->i > -1) {
-            $this->i--;
+        if ($this->currentPosition > -1) {
+            $this->currentPosition--;
         }
     }
 
@@ -89,7 +104,7 @@ class Tokenizer
      */
     public function restart()
     {
-        $this->i = -1;
+        $this->currentPosition = -1;
     }
 
     /**
@@ -98,7 +113,9 @@ class Tokenizer
      */
     public function toString()
     {
-        return implode('', array_slice($this->tokens, $this->i + 1));
+        if($this->hasNext()) {
+            return substr($this->string, $this->tokens[$this->currentPosition + 1]);
+        }
+        return '';
     }
-
 }

--- a/JBBCode/tests/TokenizerTest.php
+++ b/JBBCode/tests/TokenizerTest.php
@@ -14,35 +14,48 @@ class TokenizerTest extends PHPUnit_Framework_TestCase
     public function testEmptyString()
     {
         $tokenizer = new JBBCode\Tokenizer('');
+        $this->assertEmpty($tokenizer->toString());
         $this->assertFalse($tokenizer->hasNext());
+        $this->assertNull($tokenizer->next());
+        $this->assertEmpty($tokenizer->toString());
     }
 
     public function testPlainTextOnly()
     {
         $tokenizer = new JBBCode\Tokenizer('this is some plain text.');
+        $this->assertEquals('this is some plain text.', $tokenizer->toString());
+        $this->assertTrue($tokenizer->hasNext());
         $this->assertEquals('this is some plain text.', $tokenizer->next());
+        $this->assertFalse($tokenizer->hasNext());
         $this->assertEquals('this is some plain text.', $tokenizer->current());
         $this->assertFalse($tokenizer->hasNext());
+        $this->assertNull($tokenizer->next());
     }
 
     public function testStartingBracket()
     {
         $tokenizer = new JBBCode\Tokenizer('[this has a starting bracket.');
+        $this->assertTrue($tokenizer->hasNext());
         $this->assertEquals('[', $tokenizer->next());
         $this->assertEquals('[', $tokenizer->current());
+        $this->assertTrue($tokenizer->hasNext());
         $this->assertEquals('this has a starting bracket.', $tokenizer->next());
         $this->assertEquals('this has a starting bracket.', $tokenizer->current());
         $this->assertFalse($tokenizer->hasNext());
-        $this->assertEquals(null, $tokenizer->next());
+        $this->assertNull($tokenizer->next());
     }
 
     public function testOneTag()
     {
         $tokenizer = new JBBCode\Tokenizer('[b]');
+        $this->assertTrue($tokenizer->hasNext());
         $this->assertEquals('[', $tokenizer->next());
+        $this->assertTrue($tokenizer->hasNext());
         $this->assertEquals('b', $tokenizer->next());
+        $this->assertTrue($tokenizer->hasNext());
         $this->assertEquals(']', $tokenizer->next());
         $this->assertFalse($tokenizer->hasNext());
+        $this->assertNull($tokenizer->next());
     }
 
     public function testMatchingTags()
@@ -70,5 +83,5 @@ class TokenizerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('[', $tokenizer->next());
         $this->assertFalse($tokenizer->hasNext());
     }
-
 }
+


### PR DESCRIPTION
Building on #48, I experimented a bit with storing only token positions instead of entire tokens, leading to a slight decrease in memory usage. Results are so-so, and throughput improvements so far are within the margin of error. Still, I think this should be discussed.