### PR TITLE
Fix for BBCode rendering of ElementNode attributes

### DIFF
--- a/JBBCode/ElementNode.php
+++ b/JBBCode/ElementNode.php
@@ -125,10 +125,13 @@ class ElementNode extends Node
     {
         $str = "[".$this->tagName;
         if (!empty($this->attribute)) {
+            if(isset($this->attribute[$this->tagName])) {
+                $str .= "=".$this->attribute[$this->tagName];
+            }
 
             foreach($this->attribute as $key => $value){
                 if($key == $this->tagName){
-                    $str .= "=".$value;
+                    continue;
                 }
                 else{
                     $str .= " ".$key."=" . $value;


### PR DESCRIPTION
As the attributes can be injected freely and they are being written out in order, the current code would allow a tag to be rendered as `[tag attr=value=val]` instead of the desired `[tag=val attr=value]`.