### PR TITLE
Remove Node.nodeid

### DIFF
--- a/JBBCode/DocumentElement.php
+++ b/JBBCode/DocumentElement.php
@@ -19,7 +19,6 @@ class DocumentElement extends ElementNode
     {
         parent::__construct();
         $this->setTagName("Document");
-        $this->setNodeId(0);
     }
 
     /**

--- a/JBBCode/Node.php
+++ b/JBBCode/Node.php
@@ -14,19 +14,6 @@ abstract class Node
     /** @var Node Pointer to the parent node of this node */
     protected $parent;
 
-    /** @var integer The node id of this node */
-    protected $nodeid;
-
-    /**
-     * Returns the node id of this node. (Not really ever used. Dependent upon the parse tree the node exists within.)
-     *
-     * @return integer this node's id
-     */
-    public function getNodeId()
-    {
-        return $this->nodeid;
-    }
-
     /**
      * Returns this node's immediate parent.
      *
@@ -96,15 +83,4 @@ abstract class Node
     {
         $this->parent = $parent;
     }
-
-    /**
-     * Sets this node's nodeid
-     *
-     * @param integer $nodeid this node's node id
-     */
-    public function setNodeId($nodeid)
-    {
-        $this->nodeid = $nodeid;
-    }
-
 }

--- a/JBBCode/Parser.php
+++ b/JBBCode/Parser.php
@@ -39,9 +39,6 @@ class Parser
     /** @var CodeDefinition[] The list of bbcodes to be used by the parser. */
     protected $bbcodes = array();
 
-    /** @var integer The next node id to use. This is used while parsing. */
-    protected $nextNodeid;
-
     /**
      * Constructs an instance of the BBCode parser
      */
@@ -282,7 +279,6 @@ class Parser
         }
 
         $textNode = new TextNode($string);
-        $textNode->setNodeId(++$this->nextNodeid);
         $parent->addChild($textNode);
         return $textNode;
     }
@@ -595,7 +591,6 @@ class Parser
 
         /* If we're here, this is a valid opening tag. Let's make a new node for it. */
         $el = new ElementNode();
-        $el->setNodeId(++$this->nextNodeid);
         $code = $this->getCode($actualTagName, !empty($options));
         $el->setCodeDefinition($code);
         if (!empty($options)) {

--- a/JBBCode/Parser.php
+++ b/JBBCode/Parser.php
@@ -209,8 +209,6 @@ class Parser
     {
         // remove any old tree information
         $this->treeRoot = new DocumentElement();
-        /* The document element is created with nodeid 0. */
-        $this->nextNodeid = 1;
     }
 
     /**


### PR DESCRIPTION
because why not: It really doesn't do anything, not a single example is referencing it … and at the current stage, it isn't even possible to use it as an address for single nodes.