### PR TITLE
[WIP] Allow to pass callable as argument of CodeDefinitionBuilder::setOptionValidator/setBodyValidator()

### DIFF
--- a/JBBCode/CodeDefinitionBuilder.php
+++ b/JBBCode/CodeDefinitionBuilder.php
@@ -139,9 +139,12 @@ class CodeDefinitionBuilder
      * Removes the attached option validator if one is attached.
      * @return self
      */
-    public function removeOptionValidator()
+    public function removeOptionValidator($option=null)
     {
-        $this->optionValidator = array();
+        if(empty($option)){
+            $option = $this->tagName;
+        }
+        unset($this->optionValidator[$option]);
         return $this;
     }
 

--- a/JBBCode/InputValidator.php
+++ b/JBBCode/InputValidator.php
@@ -13,7 +13,7 @@ interface InputValidator
 {
 
     /**
-     * Returns true iff the given input is valid, false otherwise.
+     * Returns true if the given input is valid, false otherwise.
      * @param string $input
      * @return boolean
      */

--- a/JBBCode/tests/ValidatorTest.php
+++ b/JBBCode/tests/ValidatorTest.php
@@ -1,13 +1,15 @@
 <?php
 
-require_once dirname(dirname(__FILE__)) . DIRECTORY_SEPARATOR . 'Parser.php';
-require_once dirname(dirname(__FILE__)) . DIRECTORY_SEPARATOR . 'validators' . DIRECTORY_SEPARATOR . 'UrlValidator.php';
-require_once dirname(dirname(__FILE__)) . DIRECTORY_SEPARATOR . 'validators' . DIRECTORY_SEPARATOR . 'CssColorValidator.php';
+require_once __DIR__ . '/../Parser.php';
+require_once __DIR__ . '/../validators/UrlValidator.php';
+require_once __DIR__ . '/../validators/CssColorValidator.php';
+require_once __DIR__ . '/../validators/CallableValidatorAdapter.php';
 
 /**
  * Test cases for InputValidators.
  *
  * @author jbowens
+ * @author Kubo2
  * @since May 2013
  */
 class ValidatorTest extends PHPUnit_Framework_TestCase
@@ -146,6 +148,17 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
         $parser->parse('[color=" onclick="alert(\'hey ya!\');]click me[/color]');
         $this->assertEquals('[color=" onclick="alert(\'hey ya!\');]click me[/color]',
                 $parser->getAsHtml());
+    }
+
+    /**
+     * Test functionality of {@link JBBCode\CallableValidatorAdapter}
+     */
+    public function testCallableValidatorAdapter() {
+        $emptyValidator = new \JBBCode\validators\CallableValidatorAdapter(function($input) {
+            return empty($input);
+        });
+        $this->assertTrue($emptyValidator->validate(''));
+        $this->assertFalse($emptyValidator->validate('Hey! I am here'));
     }
 
 }

--- a/JBBCode/validators/CallableValidatorAdapter.php
+++ b/JBBCode/validators/CallableValidatorAdapter.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace JBBCode\validators;
+
+use JBBCode,
+	JBBCode\InputValidator;
+
+require_once __DIR__ . '/../InputValidator.php';
+
+/**
+ * An adapter for callable input validator.
+ * 
+ * This class is most often created by {@link CodeDefinitionBuilder}
+ * and used as wrapper for different types of `callable` validators.
+ *
+ * @author   Kubo2
+ * @since    August 2015
+ */
+final class CallableValidatorAdapter implements InputValidator {
+
+	/** @var callable */
+	private $validator;
+
+	/**
+	 * Constructs adapter's instance, taking `callable` validator as parameter.
+	 * 
+	 * @param callable $validator   The callable validator
+	 */
+	// public function __construct(callable $validator) { // PHP 5.3 is end-of-life, why do I have to bother with this
+	public function __construct($validator) {
+		if(!is_callable($validator)) {
+			throw new \InvalidArgumentException('$validator must be callable, ' .
+				(is_object($validator) ? get_class($validator) : gettype($validator)) . ' given');
+		}
+
+		$this->validator = $validator;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 * @return boolean   Anything returned by the callable validator, coerced to boolean
+	 */
+	public function validate($input) {
+		return (boolean) call_user_func($this->validator, $input);
+	}
+}


### PR DESCRIPTION
This is an implementation of the proposal #60.
- [x] implement ability to pass `callable`s to `setOptionValidator()`/`setBodyValidator()`
- [x] refactor the code to match coding style
- [ ] add tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jbowens/jbbcode/61)
<!-- Reviewable:end -->
