### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Documentation
 
 For complete documentation and examples visit [jbbcode.com](http://jbbcode.com).
 
-###A basic example
+### A basic example
 
 jBBCode includes a few optional, default bbcode definitions that may be loaded through the
 `DefaultCodeDefinitionSet` class. Below is a simple example of using these codes to convert


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
