### PR TITLE
Fix getAttribute return type

### DIFF
--- a/JBBCode/ElementNode.php
+++ b/JBBCode/ElementNode.php
@@ -76,7 +76,7 @@ class ElementNode extends Node
     /**
      * Returns the attribute (used as the option in bbcode definitions) of this element.
      *
-     * @return string[] the attributes of this element
+     * @return array the attributes of this element
      */
     public function getAttribute()
     {


### PR DESCRIPTION
I've been working with a [static type checker](https://github.com/phpstan/phpstan) on my code base, and the return type of `ElementNode::getAttribute` is causing some problems. It's annotated as `string[]`, but it's actually an associative array.

@DaSourcerer I also need your other PHPDoc fixes, but they haven't been tagged with a release. I get the sense this is a dead project; any interest in publishing your own fork?