### PR TITLE
fix type annotations for InputValidator

### DIFF
--- a/JBBCode/CodeDefinition.php
+++ b/JBBCode/CodeDefinition.php
@@ -29,7 +29,7 @@ class CodeDefinition
     /** @var integer How many of this element type have been seen */
     protected $elCounter;
 
-    /** @var InputValidator The input validator to run options through */
+    /** @var array[string]InputValidator The input validators to run options through */
     protected $optionValidator;
 
     /** @var InputValidator The input validator to run the body ({param}) through */

--- a/JBBCode/CodeDefinitionBuilder.php
+++ b/JBBCode/CodeDefinitionBuilder.php
@@ -23,7 +23,7 @@ class CodeDefinitionBuilder
     protected $parseContent = true;
     /** @var integer */
     protected $nestLimit = -1;
-    /** @var InputValidator[] */
+    /** @var array[string]InputValidator The input validators to run options through */
     protected $optionValidator = array();
     /** @var InputValidator */
     protected $bodyValidator = null;


### PR DESCRIPTION
Fixing another type annotation (to make static type checkers such as PHPStan happy). In this case, changing `CodeDefinition::optionValidator` and `CodeDefinitionBuilder::optionValidator` from type `InputValidator` to `array[string]InputValidator`.

Note: I validated this PHPDoc annotation syntax using PHPStan, and also [this linter](http://www.icosaedro.it/phplint/phplint-on-line.html)