### PR TITLE
Implement callable validators

### DIFF
--- a/JBBCode/tests/validators/FnValidatorTest.php
+++ b/JBBCode/tests/validators/FnValidatorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+class FnValidatorTest extends PHPUnit_Framework_TestCase
+{
+	/**
+	 * Test custom functional validator implementations.
+	 *
+	 * @param JBBCode\validators\FnValidator $validator
+	 * @dataProvider validatorProvider
+	 */
+	public function testValidator($validator)
+	{
+		$this->assertTrue($validator->validate('1234567890'));
+		$this->assertFalse($validator->validate('QWERTZUIOP'));
+	}
+
+	/**
+	 * Provide custom numeric string validator implementations.
+	 *
+	 */
+	public function validatorProvider()
+	{
+		return array(
+			array(new JBBCode\validators\FnValidator('is_numeric')),
+			array(new JBBCode\validators\FnValidator(function ($input) {
+				return is_numeric($input);
+			})),
+		);
+	}
+}

--- a/JBBCode/validators/FnValidator.php
+++ b/JBBCode/validators/FnValidator.php
@@ -34,6 +34,7 @@ class FnValidator implements \JBBCode\InputValidator
 	 */
 	public function validate($input)
 	{
-		return (bool) ($this->validator)($input);
+		$validator = $this->validator; // FIXME: for PHP>=7.0 replace with ($this->validator)($input)
+		return (bool) $validator($input);
 	}
 }

--- a/JBBCode/validators/FnValidator.php
+++ b/JBBCode/validators/FnValidator.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace JBBCode\validators;
+
+require_once dirname(dirname(__FILE__)) . DIRECTORY_SEPARATOR . 'InputValidator.php';
+
+/**
+ * An InputValidator that allows for shortcut implementation
+ * of a validator using callable types (a function or a \Closure).
+ *
+ * @author Kubo2
+ * @since Feb 2020
+ */
+class FnValidator implements \JBBCode\InputValidator
+{
+	/**
+	 * @var callable
+	 */
+	private $validator;
+
+	/**
+	 * Construct a custom validator from a callable.
+	 * @param callable $validator
+	 */
+	public function __construct(callable $validator)
+	{
+		$this->validator = $validator;
+	}
+
+	/**
+	 * Returns true iff the given input is valid, false otherwise.
+	 * @param string $input
+	 * @return boolean
+	 */
+	public function validate($input)
+	{
+		return (bool) ($this->validator)($input);
+	}
+}


### PR DESCRIPTION
Callable types may now be used to implement custom validators. Supersedes #61, resolves feature request #60. Code example (borrowed from the testcase):

```php
$defBuilder->setOptionValidator(new JBBCode\validators\FnValidator('is_numeric'));
```

/cc @jbowens @DaSourcerer 