### PR TITLE
use strict comparison when searching for a node's child

### DIFF
--- a/JBBCode/ElementNode.php
+++ b/JBBCode/ElementNode.php
@@ -185,7 +185,7 @@ class ElementNode extends Node
     public function removeChild(Node $child)
     {
         foreach ($this->children as $key => $value) {
-            if ($value == $child) {
+            if ($value === $child) {
                 unset($this->children[$key]);
             }
         }


### PR DESCRIPTION
The loose comparison used to find the child to remove from a node will compare every attributes recursively, which can lead to recursion errors ("nesting level too deep") and poor performance when you're dealing with a lot of nested nodes.

A strict comparison makes sure that it's the same instance, which should be enough.
see : https://www.php.net/manual/en/language.oop5.object-comparison.php