### PR TITLE
Fix comply with psr-0 autoloading standard

### DIFF
--- a/JBBCode/tests/DocumentElementTest.php
+++ b/JBBCode/tests/DocumentElementTest.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace JBBCode;
-
-class DocumentElementTest extends \PHPUnit_Framework_TestCase
+class DocumentElementTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var DocumentElement


### PR DESCRIPTION
I've got this warning message every time I composer update:
 ```
Class JBBCode\DocumentElementTest located in ./vendor/jbbcode/jbbcode/JBBCode/tests/DocumentElementTest.php does not comply with psr-0 autoloading standard. Skipping.
```